### PR TITLE
If Subject empty || less than 2 -> 'No Subject' in PM Subject Column

### DIFF
--- a/privateMessages.php
+++ b/privateMessages.php
@@ -55,7 +55,8 @@ class Messaging {
 		try {
 			// Check minimum length 
 			if(strlen($subject) < self::MIN_SUBJECT_LENGTH) {
-				throw new Exception("Please enter a subject!");
+				// throw new Exception("Please enter a subject!");
+				$subject = "No Subject";
 			}
 			if(strlen($recipient) < User::MIN_NAME_LENGTH) {
 				throw new Exception("Please enter a recipient!");

--- a/privateMessages.php
+++ b/privateMessages.php
@@ -56,7 +56,7 @@ class Messaging {
 			// Check minimum length 
 			if(strlen($subject) < self::MIN_SUBJECT_LENGTH) {
 				// throw new Exception("Please enter a subject!");
-				$subject = "No Subject";
+				$subject = "[No Subject]";
 			}
 			if(strlen($recipient) < User::MIN_NAME_LENGTH) {
 				throw new Exception("Please enter a recipient!");


### PR DESCRIPTION
 -modified 1 line in try catch function

 *not sure if removing an exception line is the right way to do it, but it works, I think...

![image](https://user-images.githubusercontent.com/18477656/133851039-eeb2c6d7-3296-4206-add5-c73ebcbc7cca.png)
_sent with empty subject line_